### PR TITLE
The way of injecting a DSLContext into a DAO described in README.md is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The project is deployed to Maven Central:
 ## Basic Usage
 See [Guice Persist](https://code.google.com/p/google-guice/wiki/GuicePersist) and [Transactions and Units of Work](https://code.google.com/p/google-guice/wiki/Transactions) for a reference on the basic semantics of the Guice Persist extension.
 
-In your module, install a new `com.adamlewis.guice.persist.jooq.JooqPersistModule` and then provide bindings for `javax.sql.DataSource` and `org.jooq.SQLDialect`. Then write `@Inject`able DAOs which depend on `org.jooq.DSLContext`.
+In your module, install a new `com.adamlewis.guice.persist.jooq.JooqPersistModule` and then provide bindings for `javax.sql.DataSource` and `org.jooq.SQLDialect`. Then write `@Inject`able DAOs which depend on a `com.google.inject.Provider` for `org.jooq.DSLContext`. **This is very important**: don't inject `DSLContext` directly, always use a provider - the `DSLContext` is bound to the current thread and using a provider ensures that the DAO will access the current's thread `DSLContext`. This also allows the `@Transactional` annotation to properly intercept the method call and modify the current thread's `DSLContext`.
 
 ## Example
 
@@ -61,16 +61,17 @@ Here is an example Guice module written to connect guice-persist-jooq up to the 
 And here is an example of what a DAO might look like:
 
 	public class UserDao {
-
-		private final DSLContext create;
+		// Note the usage of Provider,
+		// instead of directly injecting DSLContext
+		private final Provider<DSLContext> create;
 		
 		@Inject
-		public UserDao(final DSLContext dsl) {
+		public UserDao(final Provider<DSLContext> dsl) {
 			this.create = dsl;
 		}
 		
 		
 		public List<String> getUsernames() {
-			return create.selectDistinct(User.USER.NAME).from(User.USER).fetch(User.USER.NAME);
+			return create.get().selectDistinct(User.USER.NAME).from(User.USER).fetch(User.USER.NAME);
 		}	
 	}


### PR DESCRIPTION
Hi,
first of all, thanks for this module - it has helped immensly in setting up Guice with jOOQ.
However, I've stumbled upon an issue with the `@Transactional` annotation. Namely, it wasn't working ;) Or rather, the changes were commited to the database, even though there was a rollback... After more hours of debugging and scratching my head than I'm willing to admit, I've had a relevation - the `DSLContext` injected into the DAO and the one in `JdbcLocalTxnInterceptor` was just... not the same.

The source of the problem is that injecting `DSLContext` directly sets it to the value bound to the current thread (for example, the one doing the initialization, injecting dependencies, etc.). However, the same thread might not handle the request and a call to a `@Transactional` method/class. `@Transactional` looks up the `DSLContext` in a `ThreadLocal` and in the (very common) case I've described above, the `DSLContext` injected into the DAO and the one `JdbcLocalTxnInterceptor` will be modifing will just simply not be the same. So, `@Transactional` sets autoCommit to true, but the DAO uses a different DSLContext so it doesn't matter >_<.

This subtle difference is hinted in the [Guice's documentation about JPA](https://github.com/google/guice/wiki/JPA):

> Note that if you make `MyService` a `@Singleton`, then you should inject `Provider<EntityManager>` instead.

I've included a pull request with proposed changes to README.md that describe a proper (in my opinion) way of injecting `DSLContext` - in most cases the service and/or dao are singletons, and even if not, it won't hurt and will avoid introducing a nasty bug in case someone makes them singletons in the future.
