### PR TITLE
End unit of work after rollback

### DIFF
--- a/src/main/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptor.java
+++ b/src/main/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptor.java
@@ -20,67 +20,74 @@ import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import com.google.inject.persist.UnitOfWork;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.jooq.impl.DefaultConnectionProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
-import com.google.inject.persist.UnitOfWork;
-
 /**
  * @author Adam Lewis
  */
 class JdbcLocalTxnInterceptor implements MethodInterceptor {
-
   private static final Logger logger = LoggerFactory.getLogger(JdbcLocalTxnInterceptor.class);
-
   private static final ConcurrentMap<Method, Transactional> methodsTransactionals = new ConcurrentHashMap<Method, Transactional>();
 
-  @Inject
-  private final JooqPersistService jooqProvider = null;
-
-  @Inject
-  private final UnitOfWork unitOfWork = null;
+  private final Provider<JooqPersistService> jooqPersistServiceProvider;
+  private final Provider<UnitOfWork> unitOfWorkProvider;
 
   @Transactional
-  private static class Internal {}
+  private static class Internal {
+  }
 
   // Tracks if the unit of work was begun implicitly by this transaction.
   private final ThreadLocal<Boolean> didWeStartWork = new ThreadLocal<Boolean>();
 
+  @Inject
+  public JdbcLocalTxnInterceptor(Provider<JooqPersistService> jooqPersistServiceProvider,
+                                 Provider<UnitOfWork> unitOfWorkProvider) {
+    this.jooqPersistServiceProvider = jooqPersistServiceProvider;
+    this.unitOfWorkProvider = unitOfWorkProvider;
+  }
+
   public Object invoke(final MethodInvocation methodInvocation) throws Throwable {
+    UnitOfWork unitOfWork = unitOfWorkProvider.get();
+    JooqPersistService jooqProvider = jooqPersistServiceProvider.get();
 
     // Should we start a unit of work?
     if (!jooqProvider.isWorking()) {
-      jooqProvider.begin();
+      unitOfWork.begin();
       didWeStartWork.set(true);
     }
 
     Transactional transactional = readTransactionMetadata(methodInvocation);
-    DefaultConnectionProvider conn = this.jooqProvider.getConnectionWrapper();
+    DefaultConnectionProvider conn = jooqProvider.getConnectionWrapper();
 
     // Allow 'joining' of transactions if there is an enclosing @Transactional method.
     if (!conn.getAutoCommit()) {
       return methodInvocation.proceed();
     }
+
     logger.debug("Disabling JDBC auto commit for this thread");
     conn.setAutoCommit(false);
 
     Object result;
+
     try {
       result = methodInvocation.proceed();
-
     } catch (Exception e) {
       //commit transaction only if rollback didn't occur
       if (rollbackIfNecessary(transactional, e, conn)) {
         logger.debug("Committing JDBC transaction");
         conn.commit();
-        logger.debug("Enabling auto commit for this thread");
-        conn.setAutoCommit(true);
       }
+
+      logger.debug("Enabling auto commit for this thread");
+      conn.setAutoCommit(true);
 
       //propagate whatever exception is thrown anyway
       throw e;
@@ -92,8 +99,8 @@ class JdbcLocalTxnInterceptor implements MethodInterceptor {
       }
     }
 
-    //everything was normal so commit the txn (do not move into try block above as it
-    //  interferes with the advised method's throwing semantics)
+    // everything was normal so commit the txn (do not move into try block above as it
+    // interferes with the advised method's throwing semantics)
     try {
       logger.debug("Committing JDBC transaction");
       conn.commit();
@@ -101,7 +108,7 @@ class JdbcLocalTxnInterceptor implements MethodInterceptor {
       conn.setAutoCommit(true);
     } finally {
       //close the em if necessary
-      if (null != didWeStartWork.get() ) {
+      if (null != didWeStartWork.get()) {
         didWeStartWork.remove();
         unitOfWork.end();
       }
@@ -139,11 +146,12 @@ class JdbcLocalTxnInterceptor implements MethodInterceptor {
    * Returns True if rollback DID NOT HAPPEN (i.e. if commit should continue).
    *
    * @param transactional The metadata annotation of the method
-   * @param e The exception to test for rollback
-   * @param txn A JPA Transaction to issue rollbacks on
+   * @param e             The exception to test for rollback
+   * @param txn           A JPA Transaction to issue rollbacks on
    */
-  private boolean rollbackIfNecessary(final Transactional transactional, final Exception e,
-      final DefaultConnectionProvider conn) {
+  private boolean rollbackIfNecessary(final Transactional transactional,
+                                      final Exception e,
+                                      final DefaultConnectionProvider conn) {
     boolean commit = true;
 
     //check rollback clauses

--- a/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
+++ b/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
@@ -16,13 +16,12 @@
 
 package com.adamlewis.guice.persist.jooq;
 
-import org.aopalliance.intercept.MethodInterceptor;
-import org.jooq.DSLContext;
-
 import com.google.inject.Singleton;
 import com.google.inject.persist.PersistModule;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.jooq.DSLContext;
 
 /**
  * Jooq Factory provider for guice persist.
@@ -30,31 +29,22 @@ import com.google.inject.persist.UnitOfWork;
  * @author Adam Lewis
  */
 public final class JooqPersistModule extends PersistModule {
-
-  public JooqPersistModule() {
-    
-  }
-
   private MethodInterceptor transactionInterceptor;
 
-  @Override protected void configurePersistence() {
-    
+  @Override
+  protected void configurePersistence() {
     bind(JooqPersistService.class).in(Singleton.class);
-
     bind(PersistService.class).to(JooqPersistService.class);
     bind(UnitOfWork.class).to(JooqPersistService.class);
     bind(DSLContext.class).toProvider(JooqPersistService.class);
-    
-    transactionInterceptor = new JdbcLocalTxnInterceptor();
-    requestInjection(transactionInterceptor);
 
-    
+    transactionInterceptor = new JdbcLocalTxnInterceptor(getProvider(JooqPersistService.class),
+                                                         getProvider(UnitOfWork.class));
+    requestInjection(transactionInterceptor);
   }
 
-  @Override protected MethodInterceptor getTransactionInterceptor() {
+  @Override
+  protected MethodInterceptor getTransactionInterceptor() {
     return transactionInterceptor;
   }
-
-  
-  
 }

--- a/src/test/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptorTest.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptorTest.java
@@ -1,0 +1,92 @@
+package com.adamlewis.guice.persist.jooq;
+
+import java.lang.reflect.Method;
+
+import com.adamlewis.guice.persist.jooq.utils.MockConnection;
+import com.adamlewis.guice.persist.jooq.utils.Providers;
+import com.google.inject.persist.Transactional;
+import com.google.inject.persist.UnitOfWork;
+import org.aopalliance.intercept.MethodInvocation;
+import org.jooq.impl.DefaultConnectionProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JdbcLocalTxnInterceptorTest {
+  @Mock
+  private JooqPersistService jooqPersistService;
+  @Mock
+  private UnitOfWork unitOfWork;
+  @Mock
+  private MockConnection connection;
+  @Mock
+  private MethodInvocation methodInvocation;
+
+  private JdbcLocalTxnInterceptor interceptor;
+
+  @Transactional
+  public void transaction() {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    interceptor = new JdbcLocalTxnInterceptor(Providers.of(jooqPersistService), Providers.of(unitOfWork));
+
+    when(connection.getAutoCommit()).thenCallRealMethod();
+    doCallRealMethod().when(connection).setAutoCommit(anyBoolean());
+    connection.setAutoCommit(true);
+
+    DefaultConnectionProvider connectionProvider = new DefaultConnectionProvider(connection);
+    when(jooqPersistService.getConnectionWrapper()).thenReturn(connectionProvider);
+    when(jooqPersistService.isWorking()).thenReturn(false);
+
+    // Method is final. Mockito doesn't support mocking final classes. Using reflection
+    Method defaultTransaction = JdbcLocalTxnInterceptorTest.class.getMethod("transaction");
+    when(methodInvocation.getMethod()).thenReturn(defaultTransaction);
+  }
+
+  @Test
+  public void unitOfWorkEnds() throws Throwable {
+    interceptor.invoke(methodInvocation);
+
+    verify(unitOfWork).begin();
+    verify(connection).commit();
+    verify(unitOfWork).end();
+  }
+
+  @Test
+  public void unitOfWorkEndsOnException() throws Throwable {
+    when(methodInvocation.proceed()).thenThrow(Exception.class);
+
+    try {
+      interceptor.invoke(methodInvocation);
+      fail("exception expected");
+    } catch (Exception ignored) {
+    }
+
+    verify(unitOfWork).begin();
+    verify(connection).commit();
+    verify(unitOfWork).end();
+  }
+
+  @Test
+  public void unitOfWorkEndsOnRollbackException() throws Throwable {
+    when(methodInvocation.proceed()).thenThrow(RuntimeException.class);
+
+    try {
+      interceptor.invoke(methodInvocation);
+      fail("exception expected");
+    } catch (RuntimeException ignored) {
+    }
+
+    verify(unitOfWork).begin();
+    verify(connection).rollback();
+    verify(unitOfWork).end();
+  }
+}

--- a/src/test/java/com/adamlewis/guice/persist/jooq/utils/MockConnection.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/utils/MockConnection.java
@@ -1,0 +1,21 @@
+package com.adamlewis.guice.persist.jooq.utils;
+
+import java.sql.SQLException;
+
+public class MockConnection extends org.jooq.tools.jdbc.MockConnection {
+  private boolean autoCommit;
+
+  public MockConnection() {
+    super(null);
+  }
+
+  @Override
+  public boolean getAutoCommit() throws SQLException {
+    return autoCommit;
+  }
+
+  @Override
+  public void setAutoCommit(boolean autoCommit) throws SQLException {
+    this.autoCommit = autoCommit;
+  }
+}

--- a/src/test/java/com/adamlewis/guice/persist/jooq/utils/Providers.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/utils/Providers.java
@@ -1,0 +1,24 @@
+package com.adamlewis.guice.persist.jooq.utils;
+
+import com.google.inject.Provider;
+
+public class Providers {
+  private Providers() {
+  }
+
+  public static <T> Provider<T> of(T value) {
+    return new SimpleProvider<T>(value);
+  }
+
+  private static class SimpleProvider<T> implements Provider<T> {
+    private T value;
+
+    public SimpleProvider(T value) {
+      this.value = value;
+    }
+
+    public T get() {
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
Hi,

We noticed that the connections were not released when the interceptor triggered a rollback. 

More specifically:
The auto-commit flag was never set back to `true` and the guard in the finally block prevented the release of the connection.

I changed the way the dependencies were injected to make it easier to test. I followed the method described here: https://github.com/google/guice/wiki/AOP#Injecting_Interceptors

I added some tests. The last one verifies that `unitOfWork.end()` is called when a rollback happens.