### PR TITLE
Add support for pooled connections + cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,12 @@
 		<dependency>
 			<groupId>com.google.inject.extensions</groupId>
 			<artifactId>guice-persist</artifactId>
-			<version>3.0</version>
+			<version>5.1.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.jooq</groupId>
 			<artifactId>jooq</artifactId>
-			<version>3.5.0</version>
+			<version>3.16.4</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -83,8 +82,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
+++ b/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
@@ -16,12 +16,16 @@
 
 package com.adamlewis.guice.persist.jooq;
 
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+
 import com.google.inject.Singleton;
 import com.google.inject.persist.PersistModule;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
 import org.aopalliance.intercept.MethodInterceptor;
+import org.jooq.Configuration;
 import org.jooq.DSLContext;
+import org.jooq.conf.Settings;
 
 /**
  * Jooq Factory provider for guice persist.
@@ -33,6 +37,8 @@ public final class JooqPersistModule extends PersistModule {
 
   @Override
   protected void configurePersistence() {
+    newOptionalBinder(binder(), Settings.class);
+    newOptionalBinder(binder(), Configuration.class);
     bind(JooqPersistService.class).in(Singleton.class);
     bind(PersistService.class).to(JooqPersistService.class);
     bind(UnitOfWork.class).to(JooqPersistService.class);

--- a/src/test/java/com/adamlewis/guice/persist/jooq/modules/DataSourceModule.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/modules/DataSourceModule.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 
 public class DataSourceModule extends AbstractModule {
   public static final SQLDialect DEFAULT_DIALECT = SQLDialect.SQLITE;
+  private static final DataSource DATA_SOURCE = mock(DataSource.class);
 
   protected void configure() {
     binder().requireExplicitBindings();
@@ -18,6 +19,6 @@ public class DataSourceModule extends AbstractModule {
 
   @Provides
   public DataSource mockDataSource(){
-    return mock(DataSource.class);
+    return DATA_SOURCE;
   }
 }


### PR DESCRIPTION
* reuse acquired connection in transaction configuration
* switch to optional binder for Configuration and Settings
* log warning about ignored Settings on construction only
* bump java to 8, jOOQ to 3.16.4 and Guice to 5.1.0

Fixes #16.