### PR TITLE
Handle edge cases and support autocommit=false

### DIFF
--- a/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
+++ b/src/main/java/com/adamlewis/guice/persist/jooq/JooqPersistModule.java
@@ -46,7 +46,6 @@ public final class JooqPersistModule extends PersistModule {
 
     transactionInterceptor = new JdbcLocalTxnInterceptor(getProvider(JooqPersistService.class),
                                                          getProvider(UnitOfWork.class));
-    requestInjection(transactionInterceptor);
   }
 
   @Override

--- a/src/main/java/com/adamlewis/guice/persist/jooq/ThreadLocals.java
+++ b/src/main/java/com/adamlewis/guice/persist/jooq/ThreadLocals.java
@@ -1,0 +1,22 @@
+package com.adamlewis.guice.persist.jooq;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DefaultConnectionProvider;
+
+final class ThreadLocals {
+    private final DSLContext dslContext;
+    private final DefaultConnectionProvider connectionProvider;
+
+    ThreadLocals(DSLContext dslContext, DefaultConnectionProvider connectionProvider) {
+        this.dslContext = dslContext;
+        this.connectionProvider = connectionProvider;
+    }
+
+    DSLContext getDSLContext() {
+        return dslContext;
+    }
+
+    DefaultConnectionProvider getConnectionProvider() {
+        return connectionProvider;
+    }
+}

--- a/src/test/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptorTest.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/JdbcLocalTxnInterceptorTest.java
@@ -7,6 +7,8 @@ import com.adamlewis.guice.persist.jooq.utils.Providers;
 import com.google.inject.persist.Transactional;
 import com.google.inject.persist.UnitOfWork;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultConnectionProvider;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +45,8 @@ public class JdbcLocalTxnInterceptorTest {
     connection.setAutoCommit(true);
 
     DefaultConnectionProvider connectionProvider = new DefaultConnectionProvider(connection);
-    when(jooqPersistService.getConnectionWrapper()).thenReturn(connectionProvider);
+    when(jooqPersistService.getThreadLocals()).thenReturn(new ThreadLocals(DSL.using(SQLDialect.DEFAULT),
+                                                                           connectionProvider));
     when(jooqPersistService.isWorking()).thenReturn(false);
 
     // Method is final. Mockito doesn't support mocking final classes. Using reflection

--- a/src/test/java/com/adamlewis/guice/persist/jooq/JooqPersistServiceTest.java
+++ b/src/test/java/com/adamlewis/guice/persist/jooq/JooqPersistServiceTest.java
@@ -12,6 +12,7 @@ import com.google.inject.Module;
 import javax.sql.DataSource;
 import org.jooq.Configuration;
 import org.jooq.conf.BackslashEscaping;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +28,17 @@ public class JooqPersistServiceTest {
   public void setup() {
     injector = null;
   }
+
+  @After
+  public void tearDown() {
+      if (injector != null) {
+          JooqPersistService instance = injector.getInstance(JooqPersistService.class);
+          if (instance.isWorking()) {
+              instance.end();
+          }
+      }
+  }
+
 
   @Test
   public void canCreateWithoutConfiguration() {
@@ -65,8 +77,11 @@ public class JooqPersistServiceTest {
   }
 
   @Test
-  public void canProvideSettingsAndConfigurationButSettingsIsIgnored() {
+  public void canProvideSettingsAndConfigurationButSettingsIsIgnored() throws Exception  {
     JooqPersistService jooqPersistService = givenJooqPersistServiceWithModule(new ConfigurationModule(), new SettingsModule());
+    DataSource dataSource = injector.getInstance(DataSource.class);
+    Connection connectionMock = mock(Connection.class);
+    when(dataSource.getConnection()).thenReturn(connectionMock);
     jooqPersistService.begin();
 
     Configuration configuration = injector.getInstance(Configuration.class);


### PR DESCRIPTION
Handles https://github.com/supercargo/guice-persist-jooq/issues/14

Only tries to disable autocommit if needed.

Also handles edge cases, we internally hit a bug in where in the `catch` block we were calling `conn.setAutoCommit(true);` and there it failed, so the finally block condition `if (null != didWeStartWork.get() && conn.getAutoCommit()) {` wasn't true, and that made the connection not get released back to the connection pool, since the connection is released only during the ending of the unit of work.

So I've simplified the logic to have everything in a try catch finally block and now we are always releasing the connection to the pool.

Improved the `readTransactionMetadata` cache, as there it is a concurrent hash map, so `get` doesn't block, so if it is a cache miss, concurrent calculations will use the compute if absent, which synchronizes the calls, so we don't perform multiple calculations for the same thing at once.

Reduced the number of thread locals, and fixed it as ideally it should be a static field.

Also fixed a possible leak as if closing a the connection were to throw an error the thread local wouldn't never be removed.